### PR TITLE
Fix build tsconfig.json

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/index.ts"]
+  "include": [
+    "src/*.ts"
+  ],
+  "exclude": [
+    "src/*.test.ts"
+  ],
 }


### PR DESCRIPTION
As `1.1.0` is not published on npm (see #16), I've used npm git resolution to install the module, then `yarn install && yarn run build` in the module directory.

```json
// somewhere in my package.json
    "github-rebase": "git://github.com/tibdex/github-rebase.git#52aacd9836e54c7fadf34437f185e6449d512184",
```

But, only `src/index.ts` seems to be transpiled by `yarn run build`. Maybe it's because 52aacd9836e54c7fadf34437f185e6449d512184 also update typescript version ?

```
> yarn install
> yarn run build
> tree lib
lib
├── index.d.ts
└── index.js

0 directories, 2 files
```

Anyway, here is a possible fix.